### PR TITLE
updates to CloudTrail/Elasticsearch example

### DIFF
--- a/cloudtrail_to_elasticsearch/src/bulk_upload.py
+++ b/cloudtrail_to_elasticsearch/src/bulk_upload.py
@@ -23,8 +23,7 @@
 
 import sys
 
-from es_helper import ESHelper
-from processor import Processor
+import processor
 from s3_helper import S3Helper
 
 
@@ -32,9 +31,7 @@ if len(sys.argv) != 3:
     print(__doc__)
     sys.exit(1)
 
-# the helpers are constructed as separate objects so we can test with different params
-es = ESHelper(use_https=False)
 s3 = S3Helper()
+px = processor.create()
 
-processor = Processor(es, s3)
-s3.iterate_bucket(sys.argv[1], sys.argv[2], processor.process_from_s3)
+s3.iterate_bucket(sys.argv[1], sys.argv[2], px.process_from_s3)

--- a/cloudtrail_to_elasticsearch/src/es_helper.py
+++ b/cloudtrail_to_elasticsearch/src/es_helper.py
@@ -23,45 +23,12 @@ import os
 from aws_requests_auth.aws_auth import AWSRequestsAuth
 
 
-# modern Elasticsearch doesn't use types, but still requires a type name
-MAPPING_TYPE = "cloudtrail-event"
-
-# this is the configuration for new indices
-DEFAULT_INDEX_CONFIG = json.dumps({
-    'settings': {
-        'index.mapping.total_fields.limit': 8192
-    },
-    'mappings': {
-        MAPPING_TYPE: {
-            'dynamic_templates': [
-                {
-                    'flattened_requestParameters': {
-                            'path_match': 'requestParameters_flattened.*',
-                            'mapping': { 'type': 'text' }
-                    }
-                }, {
-                    'flattened_responseElements': {
-                            'path_match': 'responseElements_flattened.*',
-                            'mapping': { 'type': 'text' }
-                    }
-                }, {
-                    'flattened_resources': {
-                            'path_match': 'resources_flattened.*',
-                            'mapping': { 'type': 'text' }
-                    }
-                }
-            ],
-            'properties': {
-                'apiVersion': { 'type': 'text' }
-            }
-        }
-    }
-})
-
-
 class ESHelper:
 
     """ Encapsulates operations against an Elasticsearch cluster.
+
+        This is intended to be a generic helper class, not tied to CloudTrail
+        processing.
 
         By default, instances are configured to access an AWS managed Elasticsearch
         cluster, retrieving the hostname and AWS credentials from the environment.
@@ -71,7 +38,17 @@ class ESHelper:
         mock instance.
     """
 
-    def __init__(self, hostname=None, use_aws_auth=True, use_https=True):
+    def __init__(self, hostname=None, use_aws_auth=True, use_https=True, mapping_type="_doc", index_config=None):
+        """ 
+            hostname      If provided, the hostname of the Elasticsearch cluster. If not
+                          provided, this is read from the environment variable ES_HOSTNAME.
+            use_aws_auth  If true, uses AWS signed requests; if false, simple HTTP(S).
+            use_https     If true, uses HTTPS requests; if false, HTTP.
+            mapping_type  For Elasticsearch versions below 7.x, the type name used to store
+                          records. For later versions, the default (_doc) may be used.
+            index_config  If provided, used to create a new index. This is a Python object
+                          that corresponds to the Elasticsearch configuration JSON.
+        """
         if hostname:
             self.hostname = hostname
         else:
@@ -92,6 +69,8 @@ class ESHelper:
             self.protocol = "https"
         else:
             self.protocol = "http"
+        self.index_config = index_config
+        self.mapping_type = mapping_type
     
 
     def upload(self, events, index):
@@ -113,8 +92,11 @@ class ESHelper:
         if rsp.status_code == 200:
             return
         elif rsp.status_code == 404:
-            print("creating index")
-            rsp = self.do_request(requests.put, index, DEFAULT_INDEX_CONFIG)
+            print(f"creating index: {index}")
+            if self.index_config:
+                rsp = self.do_request(requests.put, index, self.index_config)
+            else:
+              pass  # first PUT will create index
             if rsp.status_code != 200:
                 raise Exception(f'failed to create index: {rsp.text}')
         else:
@@ -123,7 +105,7 @@ class ESHelper:
 
     def prepare_event(self, event, index):
         return "\n".join([
-            json.dumps({ "index": { "_index": index, "_type": MAPPING_TYPE, "_id": event['eventID'] }}),
+            json.dumps({ "index": { "_index": index, "_type": self.mapping_type, "_id": event['eventID'] }}),
             json.dumps(event)
             ]) + "\n"
 
@@ -148,11 +130,9 @@ class ESHelper:
         if not result.get('errors'):
             print("no errors")
             return
-        messages = set()
         failed_records = set()
         for item in result.get('items', []):
             item = item.get('index', {})
             if item.get('status', 500) > 299:
-                messages.add(item.get('error', {}).get('reason'))
                 failed_records.add(item.get('_id'))
-        print(f'upload failed for {len(failed_records)} records:\n{messages}')
+        print(f'upload failed for {len(failed_records)} records: {list(failed_records)[:5]}')

--- a/cloudtrail_to_elasticsearch/src/index.py
+++ b/cloudtrail_to_elasticsearch/src/index.py
@@ -17,11 +17,9 @@
 """ Lambda function to upload CloudTrail events to Elasticsearch
 """
 
-from es_helper import ESHelper
-from processor import Processor
-from s3_helper import S3Helper
+import processor
 
-processor = Processor(ESHelper(), S3Helper())
+px = processor.create()
 
 def lambda_handler(event, context):
     for record in event.get('Records', []):
@@ -30,6 +28,6 @@ def lambda_handler(event, context):
         key = record['s3']['object']['key']
         try:
             print(f"processing s3://{bucket}/{key}")
-            processor.process_from_s3(bucket, key)
+            px.process_from_s3(bucket, key)
         except Exception as ex:
             print(f"failed to process file: {ex}")

--- a/cloudtrail_to_elasticsearch/src/index.py
+++ b/cloudtrail_to_elasticsearch/src/index.py
@@ -28,4 +28,8 @@ def lambda_handler(event, context):
         eventName = record['eventName']
         bucket = record['s3']['bucket']['name']
         key = record['s3']['object']['key']
-        processor.process_from_s3(bucket, key)
+        try:
+            print(f"processing s3://{bucket}/{key}")
+            processor.process_from_s3(bucket, key)
+        except Exception as ex:
+            print(f"failed to process file: {ex}")

--- a/cloudtrail_to_elasticsearch/src/processor.py
+++ b/cloudtrail_to_elasticsearch/src/processor.py
@@ -131,7 +131,9 @@ def flatten(event, key):
 
 def flatten_dict(src, dst):
     for key in src.keys():
-        flatten_item(key, src[key], dst)
+        # CloudTrail events sometimes contains blank keys; we'll skip those
+        if key:
+            flatten_item(key, src[key], dst)
     return dst
 
 

--- a/cloudtrail_to_elasticsearch/src/processor.py
+++ b/cloudtrail_to_elasticsearch/src/processor.py
@@ -20,8 +20,51 @@ import os
 import re
 import sys
 
-import es_helper
-import s3_helper
+from es_helper import ESHelper
+from s3_helper import S3Helper
+
+
+# the index configuration that we'll use
+
+DEFAULT_MAPPING_TYPE = "cloudtrail-event"
+
+DEFAULT_INDEX_CONFIG = json.dumps({
+    'settings': {
+        'index.mapping.total_fields.limit': 8192
+    },
+    'mappings': {
+        DEFAULT_MAPPING_TYPE: {
+            'dynamic_templates': [
+                {
+                    'flattened_requestParameters': {
+                            'path_match': 'requestParameters_flattened.*',
+                            'mapping': { 'type': 'text' }
+                    }
+                }, {
+                    'flattened_responseElements': {
+                            'path_match': 'responseElements_flattened.*',
+                            'mapping': { 'type': 'text' }
+                    }
+                }, {
+                    'flattened_resources': {
+                            'path_match': 'resources_flattened.*',
+                            'mapping': { 'type': 'text' }
+                    }
+                }
+            ],
+            'properties': {
+                'apiVersion': { 'type': 'text' }
+            }
+        }
+    }
+})
+
+
+def create():
+  """ Factory method to create a default instance.
+  """
+  return Processor(ESHelper(mapping_type=DEFAULT_MAPPING_TYPE, index_config=DEFAULT_INDEX_CONFIG),
+                   S3Helper())
 
 
 class Processor:
@@ -37,7 +80,6 @@ class Processor:
     def process_from_s3(self, bucket, key):
         index = index_name(key)
         if index:
-            print(f'processing s3://{bucket}/{key}')
             content = self.s3_helper.retrieve(bucket, key)
             self.process(content, index)
         else:
@@ -114,6 +156,9 @@ def flatten_item(key, val, dst):
 def transform_flattened_elements(src):
     dst = {}
     for (k, v) in src.items():
+        # Elasticsearch doesn't like keys that have dots in them
+        k = k.replace(".", "_")
+        # json.dumps() doesn't like sets
         if isinstance(v, set):
             tmp = v
             v = list()


### PR DESCRIPTION
* fix bug where records would be rejected because some fields had dots in their name
* fix bug where records would be rejected because a child object key was an empty string
* add default index mappings to avoid field conflicts