### PR TITLE
cloudtrail_to_elasticsearch: rewrite bulk upload

### DIFF
--- a/cloudtrail_to_elasticsearch/cloudtrail_to_elasticsearch/bulk_upload.py
+++ b/cloudtrail_to_elasticsearch/cloudtrail_to_elasticsearch/bulk_upload.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 ################################################################################
-# Copyright 2019 Chariot Solutions
+# Copyright Chariot Solutions
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,23 +15,132 @@
 # limitations under the License.
 ################################################################################
 
-""" Bulk-loads events that have been stored but not picked up by Lambda. This
-    module is only intended to be invoked from the command-line:
+""" Bulk-loads events: reads files from either S3 or the local filesystem,
+    batches them as possible, and writes to Elasticsearch.
 
-        bulk_upload.py BUCKET_NAME PREFIX
+    Intended to be invoked from the command-line, using one of these forms:
+
+        python -m cloudtrail_to_elasticsearch.bulk_upload [--dates START_DATE END_DATE] --s3 BUCKET_NAME [PREFIX]
+        python -m cloudtrail_to_elasticsearch.bulk_upload [--dates START_DATE END_DATE] --local FILE_OR_DIRECTORY
+
+    Must have the following environment variables set:
 """
 
+import argparse
+import os
+import pathlib
+import re
 import sys
 
 from cloudtrail_to_elasticsearch import processor
 from cloudtrail_to_elasticsearch.s3_helper import S3Helper
 
 
-if len(sys.argv) != 3:
-    print(__doc__)
-    sys.exit(1)
+##
+## Environment variables - dereference here to fail fast
+##
+
+ES_HOSTNAME = os.environ['ES_HOSTNAME']
+
+
+##
+## Invocation arguments
+##
+
+arg_parser = argparse.ArgumentParser(description="Bulk-uploads CloudTrail events to Elasticsearch")
+
+arg_parser.add_argument("--dates",
+                        nargs=2,
+                        metavar="START_DATE END_DATE",
+                        dest='date_range',
+                        help="""Starting and ending rate range for selected files, in form
+                                YYYY-MM-DD. These are matched against the date embedded in
+                                the filename. To select an unbounded range, use 0000-01-01
+                                for the low end, 9999-12-31 for the high end.
+                                """)
+
+arg_parser.add_argument("--local",
+                        metavar="FILE_OR_DIRECTORY",
+                        dest='local_path',
+                        help="""A single file or directory of files to be uploaded.
+                                """)
+arg_parser.add_argument("--s3",
+                        nargs="+",
+                        metavar=("BUCKET", "PREFIX"),
+                        dest='s3_config',
+                        help="""Destination on S3 where CloudTrail files are located, with optional prefix.
+                                Can restrict the files that are processed by providing start and end dates,
+                                formatted "YYYY-MM-DD"; use dummy values (eg, "9999-12-31") to bound on one
+                                side only.
+                                """)
+args = arg_parser.parse_args()
+
+args.date_range = args.date_range or ("0000-01-01", "9999-12-31")
+args.date_start = args.date_range[0].replace("-", "")
+args.date_finish = args.date_range[1].replace("-", "")
+
+
+##
+## Helper functions
+##
+
+FILENAME_REGEX = re.compile(r".*_CloudTrail_[^_]*_(\d{8})T\d{4}Z_.*json.gz")
+
+def include_file(filename):
+    """ Verifies that the passed filename matches a CloudTrail upload file, and
+        that it's between the configured dates.
+        """
+    m = FILENAME_REGEX.match(filename)
+    return m and m.group(1) >= args.date_start and m.group(1) <= args.date_finish
+
+
+def local_files(root):
+    """ Retrieves a list of files from the local filesystem that match the
+        specified date range.
+        """
+    def recursive_select(path, acc):
+        if path.is_file():
+            filename = str(path)
+            if include_file(filename):
+                acc.append(filename)
+        else:
+            for child in pathlib.Path(path).iterdir():
+                recursive_select(child, acc)
+    result = []
+    recursive_select(pathlib.Path(root), result)
+    return result
+
+
+def s3_files(s3_helper, bucket, prefix):
+    """ Retrieves a list of files from S3 that match the provided date range.
+        """
+    file_list = []
+    def select_files(b,k):
+        if include_file(k):
+            file_list.append(k)
+    s3_helper.iterate_bucket(bucket, prefix, select_files)
+    return file_list
+
+
+##
+## The main event
+##
 
 s3 = S3Helper()
 px = processor.create()
 
-s3.iterate_bucket(sys.argv[1], sys.argv[2], px.process_from_s3)
+if args.local_path:
+    for filename in local_files(args.local_path):
+        print(f"processing local file: {filename}")
+        px.process_local_file(filename, flush=False)
+    px.flush()
+elif args.s3_config:
+    bucket = args.s3_config[0]
+    prefix = args.s3_config[1] if len(args.s3_config) > 1 else ""
+    for key in s3_files(s3, bucket, prefix):
+        print(f"processing S3 file: s3://{bucket}/{key}")
+        px.process_from_s3(bucket, key, flush=False)
+    px.flush()
+else:
+    print("", file=sys.stderr)
+    arg_parser.print_help()

--- a/cloudtrail_to_elasticsearch/cloudtrail_to_elasticsearch/processor.py
+++ b/cloudtrail_to_elasticsearch/cloudtrail_to_elasticsearch/processor.py
@@ -19,6 +19,7 @@
     """
 
 
+import gzip
 import json
 import os
 import re
@@ -80,6 +81,19 @@ class Processor:
     def __init__(self, es_helper, s3_helper):
         self.es_helper = es_helper
         self.s3_helper = s3_helper
+
+
+    def process_local_file(self, pathname, flush=True):
+        index = index_name(pathname)
+        if index:
+            with open (pathname, mode='rb') as f:
+                data = f.read()
+            if data.startswith(b'\x1f\x8b'):
+                 data = gzip.decompress(data)
+            self.process(str(data, 'utf-8'), index, flush)
+        else:
+            print(f'cannot extract index name from key: {key}')
+
 
     def process_from_s3(self, bucket, key, flush=True):
         index = index_name(key)

--- a/cloudtrail_to_elasticsearch/cloudtrail_to_elasticsearch/processor.py
+++ b/cloudtrail_to_elasticsearch/cloudtrail_to_elasticsearch/processor.py
@@ -103,12 +103,14 @@ class Processor:
         else:
             print(f'cannot extract index name from key: {key}')
 
+
     def process(self, content, index, flush=True):
         parsed = json.loads(content)
         transformed = transform_events(parsed.get('Records', []))
         self.es_helper.add_events(transformed, index)
         if flush:
             self.flush()
+
 
     def flush(self):
         self.es_helper.flush()

--- a/cloudtrail_to_elasticsearch/poetry.lock
+++ b/cloudtrail_to_elasticsearch/poetry.lock
@@ -1,26 +1,4 @@
 [[package]]
-name = "atomicwrites"
-version = "1.4.0"
-description = "Atomic file writes."
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
-name = "attrs"
-version = "21.2.0"
-description = "Classes Without Boilerplate"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-
-[package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
-
-[[package]]
 name = "aws-requests-auth"
 version = "0.4.3"
 description = "AWS signature version 4 signing process for the python requests module"
@@ -33,36 +11,39 @@ requests = ">=0.14.0"
 
 [[package]]
 name = "boto3"
-version = "1.18.8"
+version = "1.22.3"
 description = "The AWS SDK for Python"
 category = "dev"
 optional = false
 python-versions = ">= 3.6"
 
 [package.dependencies]
-botocore = ">=1.21.8,<1.22.0"
-jmespath = ">=0.7.1,<1.0.0"
+botocore = ">=1.25.3,<1.26.0"
+jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.5.0,<0.6.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.21.8"
+version = "1.25.3"
 description = "Low-level, data-driven core of boto 3."
 category = "dev"
 optional = false
 python-versions = ">= 3.6"
 
 [package.dependencies]
-jmespath = ">=0.7.1,<1.0.0"
+jmespath = ">=0.7.1,<2.0.0"
 python-dateutil = ">=2.1,<3.0.0"
 urllib3 = ">=1.25.4,<1.27"
 
 [package.extras]
-crt = ["awscrt (==0.11.24)"]
+crt = ["awscrt (==0.13.8)"]
 
 [[package]]
 name = "certifi"
-version = "2021.5.30"
+version = "2021.10.8"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -70,7 +51,7 @@ python-versions = "*"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.3"
+version = "2.0.12"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -80,95 +61,20 @@ python-versions = ">=3.5.0"
 unicode_backport = ["unicodedata2"]
 
 [[package]]
-name = "colorama"
-version = "0.4.4"
-description = "Cross-platform colored terminal text."
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-
-[[package]]
 name = "idna"
-version = "3.2"
+version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [[package]]
-name = "iniconfig"
-version = "1.1.1"
-description = "iniconfig: brain-dead simple config-ini parsing"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "jmespath"
-version = "0.10.0"
+version = "1.0.0"
 description = "JSON Matching Expressions"
 category = "dev"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-
-[[package]]
-name = "packaging"
-version = "21.0"
-description = "Core utilities for Python packages"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-pyparsing = ">=2.0.2"
-
-[[package]]
-name = "pluggy"
-version = "0.13.1"
-description = "plugin and hook calling mechanisms for python"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[package.extras]
-dev = ["pre-commit", "tox"]
-
-[[package]]
-name = "py"
-version = "1.10.0"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
-name = "pyparsing"
-version = "2.4.7"
-description = "Python parsing module"
-category = "dev"
-optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-
-[[package]]
-name = "pytest"
-version = "6.2.4"
-description = "pytest: simple powerful testing with Python"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
-attrs = ">=19.2.0"
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-iniconfig = "*"
-packaging = "*"
-pluggy = ">=0.12,<1.0.0a1"
-py = ">=1.8.2"
-toml = "*"
-
-[package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+python-versions = ">=3.7"
 
 [[package]]
 name = "python-dateutil"
@@ -201,7 +107,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "s3transfer"
-version = "0.5.0"
+version = "0.5.2"
 description = "An Amazon S3 Transfer Manager"
 category = "dev"
 optional = false
@@ -222,95 +128,51 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
-category = "dev"
-optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-
-[[package]]
 name = "urllib3"
-version = "1.26.6"
+version = "1.26.9"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
-brotli = ["brotlipy (>=0.6.0)"]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.8"
-content-hash = "3f0e0f2f39b96d3623185501d031c298b54fb930f05484b211b80cbea3192c52"
+python-versions = "^3.7"
+content-hash = "a0741d1514c7559486b0e348b073f8f2cdf5b997760580628dcdd107ac1ebfe3"
 
 [metadata.files]
-atomicwrites = [
-    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
-    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
-]
-attrs = [
-    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
-    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
-]
 aws-requests-auth = [
     {file = "aws-requests-auth-0.4.3.tar.gz", hash = "sha256:33593372018b960a31dbbe236f89421678b885c35f0b6a7abfae35bb77e069b2"},
     {file = "aws_requests_auth-0.4.3-py2.py3-none-any.whl", hash = "sha256:646bc37d62140ea1c709d20148f5d43197e6bd2d63909eb36fa4bb2345759977"},
 ]
 boto3 = [
-    {file = "boto3-1.18.8-py3-none-any.whl", hash = "sha256:7ed86cc669bcfa60ef854cc2fbc2d300a8331fb1befdc7eabc51ce013659e86c"},
-    {file = "boto3-1.18.8.tar.gz", hash = "sha256:19cff13dd9b51ce66fad13c9f04ffcc12d5475dd8cd660e8cd6aac42aa45c24c"},
+    {file = "boto3-1.22.3-py3-none-any.whl", hash = "sha256:b291e9b8057158c4ee75a7df8ab22079b4ab915f032af59bcae22677f2a6ceda"},
+    {file = "boto3-1.22.3.tar.gz", hash = "sha256:ef66e2e4f05f0d20aab20b1b655dc670db5c9324d33db6754b576c6867c2ffe9"},
 ]
 botocore = [
-    {file = "botocore-1.21.8-py3-none-any.whl", hash = "sha256:e51ac230169af1325ab64c9935e679fb54f6d3fdf0978fe67a31931febdf94f9"},
-    {file = "botocore-1.21.8.tar.gz", hash = "sha256:437cdcd518e6f9db72ec87f170cc66d54081c8abc347abb9f9a3cd9c8e993bd1"},
+    {file = "botocore-1.25.3-py3-none-any.whl", hash = "sha256:b63343736f1e778f9a658736afd9773ea38b3605d96556fb5585fc0c04a0d1e1"},
+    {file = "botocore-1.25.3.tar.gz", hash = "sha256:c807e14b956b4b11d6872e84d1d947d1da5ffeedf8aac569a6401063e1752abd"},
 ]
 certifi = [
-    {file = "certifi-2021.5.30-py2.py3-none-any.whl", hash = "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"},
-    {file = "certifi-2021.5.30.tar.gz", hash = "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"},
+    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
+    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.3.tar.gz", hash = "sha256:c46c3ace2d744cfbdebceaa3c19ae691f53ae621b39fd7570f59d14fb7f2fd12"},
-    {file = "charset_normalizer-2.0.3-py3-none-any.whl", hash = "sha256:88fce3fa5b1a84fdcb3f603d889f723d1dd89b26059d0123ca435570e848d5e1"},
-]
-colorama = [
-    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
-    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
+    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 idna = [
-    {file = "idna-3.2-py3-none-any.whl", hash = "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a"},
-    {file = "idna-3.2.tar.gz", hash = "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"},
-]
-iniconfig = [
-    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
-    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
+    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 jmespath = [
-    {file = "jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"},
-    {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
-]
-packaging = [
-    {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},
-    {file = "packaging-21.0.tar.gz", hash = "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7"},
-]
-pluggy = [
-    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
-    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
-]
-py = [
-    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
-    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
-]
-pyparsing = [
-    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
-    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
-]
-pytest = [
-    {file = "pytest-6.2.4-py3-none-any.whl", hash = "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"},
-    {file = "pytest-6.2.4.tar.gz", hash = "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b"},
+    {file = "jmespath-1.0.0-py3-none-any.whl", hash = "sha256:e8dcd576ed616f14ec02eed0005c85973b5890083313860136657e24784e4c04"},
+    {file = "jmespath-1.0.0.tar.gz", hash = "sha256:a490e280edd1f57d6de88636992d05b71e97d69a26a19f058ecf7d304474bf5e"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
@@ -321,18 +183,14 @@ requests = [
     {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
 ]
 s3transfer = [
-    {file = "s3transfer-0.5.0-py3-none-any.whl", hash = "sha256:9c1dc369814391a6bda20ebbf4b70a0f34630592c9aa520856bf384916af2803"},
-    {file = "s3transfer-0.5.0.tar.gz", hash = "sha256:50ed823e1dc5868ad40c8dc92072f757aa0e653a192845c94a3b676f4a62da4c"},
+    {file = "s3transfer-0.5.2-py3-none-any.whl", hash = "sha256:7a6f4c4d1fdb9a2b640244008e142cbc2cd3ae34b386584ef044dd0f27101971"},
+    {file = "s3transfer-0.5.2.tar.gz", hash = "sha256:95c58c194ce657a5f4fb0b9e60a84968c808888aed628cd98ab8771fe1db98ed"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
-toml = [
-    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
-    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
-]
 urllib3 = [
-    {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},
-    {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
+    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
+    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
 ]


### PR DESCRIPTION
The original implementation just put a "let's iterate all the S3 objects" on top of the Lambda implementation. Now it will accumulate events and push them out to Elasticsearch every 500 rows. Still not very performant if you're reading lots of small files from S3, but at least it's not pounding Elasticsearch with tiny updates.