### PR TITLE
updates to "cloudtrail_to_elasticsearch"

### DIFF
--- a/cloudtrail_to_elasticsearch/Makefile.pip
+++ b/cloudtrail_to_elasticsearch/Makefile.pip
@@ -1,6 +1,6 @@
 .PHONY: default deploy package init clean
 
-LAMBDA_NAME     ?= CloudTrail_to_Elasticsearch
+LAMBDA_NAME     ?= CloudTrail_to_OpenSearch
 
 SRC_DIR         := $(PWD)/cloudtrail_to_elasticsearch
 BUILD_DIR       := $(PWD)/build

--- a/cloudtrail_to_elasticsearch/Makefile.poetry
+++ b/cloudtrail_to_elasticsearch/Makefile.poetry
@@ -1,6 +1,6 @@
 .PHONY: default deploy package test quicktest init clean
 
-LAMBDA_NAME     ?= CloudTrail_to_Elasticsearch
+LAMBDA_NAME     ?= CloudTrail_to_OpenSearch
 
 POETRY_DIST_DIR := $(PWD)/dist
 BUILD_DIR       := $(PWD)/build

--- a/cloudtrail_to_elasticsearch/README.md
+++ b/cloudtrail_to_elasticsearch/README.md
@@ -248,10 +248,10 @@ While the Lambda could explicitly transform each event into a standard format, t
 endless task: AWS constantly adds new API calls. Moreover, dynamic mapping is one of Elasticsearch's
 strengths; we should use it.
 
-My solution is to "flatten" the `requestParameters`, `responseElements`, and `resources` sub-objects
-before writing the event. This is best explained by example: the `RunInstances` API call returns an
-array of objects, one per instance created. The CloudTrail event looks like this (showing only the
-fields relevant to this example):
+My solution is to "flatten" the `requestParameters`, `responseElements`, `serviceEventDetails`, and
+`resources` sub-objects before writing the event. This is best explained by example: the `RunInstances`
+API call returns an array of objects, one per instance created. The CloudTrail event looks like this
+(showing only the fields relevant to this example):
 
 ```
 {

--- a/cloudtrail_to_elasticsearch/cloudformation.yml
+++ b/cloudtrail_to_elasticsearch/cloudformation.yml
@@ -1,17 +1,16 @@
 AWSTemplateFormatVersion:               "2010-09-09"
-Description:                            "Creates an Elasticsearch cluster and a Lambda function that will write CloudTrail events into it"
+Description:                            "Creates an OpenSearch cluster and a Lambda function that will write CloudTrail events into it"
 
 Parameters:
 
   LambdaName:
     Description:                        "Name for the Lambda function and associated resources"
     Type:                               "String"
-    Default:                            "CloudTrail_to_Elasticsearch"
+    Default:                            "CloudTrail_to_OpenSearch"
 
   CloudTrailBucket:
     Description:                        "The S3 bucket that holds CloudTrail events"
     Type:                               "String"
-    Default:                            ""
 
   CloudTrailPrefix:
     Description:                        "The path in that bucket for new CloudTrail event files, with trailing slash"
@@ -26,20 +25,20 @@ Parameters:
   OpenSearchInstanceType:
     Description:                        "Type of instance used for OpenSearch cluster; default is useful for small environment"
     Type:                               "String"
-    Default:                            "t3.medium.search"
+    Default:                            "t3.small.search"
 
   OpenSearchStorageType:
     Description:                        "Type of the OpenSearch storage volume (allowed types depend on instance type)"
     Type:                               "String"
-    Default:                            "gp2"
+    Default:                            "gp3"
 
   OpenSearchStorageSize:
     Description:                        "Size of the OpenSearch storage volume, in GB (allowed sizes depend on instance type)"
     Type:                               "Number"
-    Default:                            32
+    Default:                            64
 
   AllowedIPs:
-    Description:                        "IP addresses that are allowed to access Elasticsearch/Kibana (leave blank for none)"
+    Description:                        "IP addresses that are allowed to access OpenSearch/Kibana (leave blank for none)"
     Type:                               "CommaDelimitedList"
     Default:                            ""
 
@@ -50,11 +49,13 @@ Resources:
   ## OpenSearch cluster
   ##
 
-  ElasticSearchDomain:
+  OpenSearchDomain:
     Type:                               "AWS::OpenSearchService::Domain"
+    UpdatePolicy:
+      EnableVersionUpgrade:             true
     Properties:
       DomainName:                       !Ref OpenSearchDomainName
-      EngineVersion:                    "OpenSearch_1.2"
+      EngineVersion:                    "OpenSearch_2.5"
       ClusterConfig:
         InstanceType:                   !Ref OpenSearchInstanceType
         InstanceCount:                  1
@@ -124,14 +125,14 @@ Resources:
             Statement:
               Effect:                   "Allow"
               Action:                   [ "es:ESHttpGet", "es:ESHttpPost", "es:ESHttpPut" ]
-              Resource:                 [ !Sub "${ElasticSearchDomain.Arn}/*" ]
+              Resource:                 [ !Sub "${OpenSearchDomain.Arn}/*" ]
 
 
   LambdaFunction:
     Type:                               "AWS::Lambda::Function"
     Properties: 
       FunctionName:                     !Ref LambdaName
-      Description:                      "Reacts to CloudTrail files being stored on S3 by uploading them to Elasticsearch"
+      Description:                      "Reacts to CloudTrail files being stored on S3 by uploading them to OpenSearch"
       Role:                             !GetAtt LambdaRole.Arn
       Runtime:                          "python3.9"
       Handler:                          "cloudtrail_to_elasticsearch.lambda_handler.handle"
@@ -141,4 +142,4 @@ Resources:
       Timeout:                          60
       Environment: 
         Variables:
-          ES_HOSTNAME:                  !GetAtt ElasticSearchDomain.DomainEndpoint
+          ES_HOSTNAME:                  !GetAtt OpenSearchDomain.DomainEndpoint

--- a/cloudtrail_to_elasticsearch/cloudtrail_to_elasticsearch/es_helper.py
+++ b/cloudtrail_to_elasticsearch/cloudtrail_to_elasticsearch/es_helper.py
@@ -21,6 +21,8 @@ import os
 
 from aws_requests_auth.aws_auth import AWSRequestsAuth
 
+DEFAULT_BATCH_SIZE = 7680 * 1024
+
 
 class ESHelper:
 
@@ -40,7 +42,7 @@ class ESHelper:
         mock instance.
     """
 
-    def __init__(self, hostname=None, use_aws_auth=True, use_https=True, index_config=None, batch_size=500):
+    def __init__(self, hostname=None, use_aws_auth=True, use_https=True, index_config=None, batch_size=DEFAULT_BATCH_SIZE):
         """
             hostname      If provided, the hostname of the Elasticsearch cluster. If not
                           provided, this is read from the environment variable ES_HOSTNAME.
@@ -48,6 +50,9 @@ class ESHelper:
             use_https     If true, uses HTTPS requests; if false, HTTP.
             index_config  If provided, used to create a new index. This is a Python object
                           that corresponds to the Elasticsearch configuration JSON.
+            batch_size    if provided, defines a trigger for writing batches to Elasticsearch.
+                          AWS Opensearch has been observed to reject requests > 1 MB, even
+                          though the Elasticsearch docs say that it will accept up to 100 MB.
         """
         if hostname:
             self.hostname = hostname
@@ -70,9 +75,10 @@ class ESHelper:
         else:
             self.protocol = "http"
         self.index_config = index_config
-        self.batch_size = batch_size
+        self.max_batch_size = batch_size
         self.current_index = None
-        self.batch = []
+        self.current_batch = []
+        self.current_batch_size = 0
 
 
     def add_events(self, events, index):
@@ -83,9 +89,19 @@ class ESHelper:
         if self.current_index != index:
             self.flush()  # this is a no-op first time through
             self.current_index = index
-        self.batch += events
-        if len(self.batch) > self.batch_size:
-            self.flush()
+        for event in events:
+            prepared = self.prepare_event(event, self.current_index)
+            self.current_batch.append(prepared)
+            self.current_batch_size += len(prepared)
+            if self.current_batch_size > self.max_batch_size:
+                self.flush()
+
+
+    def prepare_event(self, event, index):
+        return "\n".join([
+            json.dumps({ "index": { "_index": index, "_id": event['eventID'] }}),
+            json.dumps(event)
+            ]) + "\n"
 
 
     def flush(self):
@@ -93,17 +109,16 @@ class ESHelper:
             the batch.
             """
         # no-op to simplify calling code
-        if not self.current_index or not self.batch:
+        if not self.current_index or not self.current_batch:
             return
-        print(f'writing {len(self.batch)} events to index {self.current_index}')
         self.ensure_index_exists(self.current_index)
-        updates = [self.prepare_event(event, self.current_index) for event in self.batch]
-        rsp = self.do_request(requests.post, "_bulk", "".join(updates), 'application/x-ndjson')
+        print(f'writing {len(self.current_batch)} events to index {self.current_index}')
+        rsp = self.do_request(requests.post, "_bulk", "".join(self.current_batch), 'application/x-ndjson')
         if rsp.status_code == 200:
             # individual records may be rejected -- we'll assume them damaged and drop
             self.log_record_errors(rsp)
-            self.current_index = None
-            self.batch = []
+            self.current_batch = []
+            self.current_batch_size = 0
         elif rsp.status_code == 429:
             print(f'upload throttled; retrying')
             # we'll hope that it succeeds before we blow stack
@@ -122,22 +137,15 @@ class ESHelper:
         if rsp.status_code == 200:
             return
         elif rsp.status_code == 404:
-            print(f"creating index: {index}")
-            if self.index_config:
+            if self.index_config:    
+                print(f"creating index: {index}")
                 rsp = self.do_request(requests.put, index, self.index_config)
+                if rsp.status_code != 200:
+                    raise Exception(f'failed to create index: {rsp.text}')
             else:
               pass  # first PUT will create index
-            if rsp.status_code != 200:
-                raise Exception(f'failed to create index: {rsp.text}')
         else:
             print(f'failed to retrieve index status: {rsp.text}')
-
-
-    def prepare_event(self, event, index):
-        return "\n".join([
-            json.dumps({ "index": { "_index": index, "_id": event['eventID'] }}),
-            json.dumps(event)
-            ]) + "\n"
 
 
     def do_request(self, fn, path, body=None, content_type='application/json'):

--- a/cloudtrail_to_elasticsearch/cloudtrail_to_elasticsearch/processor.py
+++ b/cloudtrail_to_elasticsearch/cloudtrail_to_elasticsearch/processor.py
@@ -44,12 +44,20 @@ DEFAULT_INDEX_CONFIG = json.dumps({
                         'path_match': 'requestParameters_flattened.*',
                         'mapping': { 'type': 'text' }
                 }
-            }, {
+            }, 
+            {
                 'flattened_responseElements': {
                         'path_match': 'responseElements_flattened.*',
                         'mapping': { 'type': 'text' }
                 }
-            }, {
+            },
+            {
+                'flattened_serviceEventDetails': {
+                        'path_match': 'serviceEventDetails_flattened.*',
+                        'mapping': { 'type': 'text' }
+                }
+            },
+            {
                 'flattened_resources': {
                         'path_match': 'resources_flattened.*',
                         'mapping': { 'type': 'text' }
@@ -133,6 +141,7 @@ def transform_events(events):
         flatten(event, 'requestParameters')
         flatten(event, 'responseElements')
         flatten(event, 'resources')
+        flatten(event, 'serviceEventDetails')
     return events
 
 


### PR DESCRIPTION
A general refresh, and some changes prompted by our own usage of this Lambda.

* **Construct batches based on size, not count**

  The previous version wrote 500 records in a batch. We were seeing batches rejected because the total request size was > 10 MB (this is a limitation of the instance type; [larger instances can have requests up to 100MB](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/limits.html#network-limits)). The change uses 7.5 MB as a target batch size, which normally fits around 2,000 events.

* **Flatten the `serviceEventDetails` sub-object**

  We were seeing individual records being rejected, and on further investigation they all contained this sub-object. We suspect that it was another case where an existing dynamic mapping didn't fit the data of a service that we started using.

* **Updates to CloudFormation template**

   * Use OpenSearch version 2.5
   * Change default node type to `t3.small.search`, which is sufficient for most use-cases.
   * Change default storage to GP3, because it's more performant than GP2.
   * Rename logical IDs to use `OpenSearch` rather than `Elasticsearch`.

* **Minor changes to the README**